### PR TITLE
fix decodeValueDescriptorSlice()

### DIFF
--- a/coredataclients/coredata-clients.go
+++ b/coredataclients/coredata-clients.go
@@ -60,7 +60,7 @@ func makeRequest(req *http.Request) (*http.Response, error) {
 }
 
 // Help method to decode a valuedescriptor slice
-func decodeValueDescriptorSlice(resp *http.Response) ([]models.ValueDescriptor, error) {
+func (v *ValueDescriptorClient) decodeValueDescriptorSlice(resp *http.Response) ([]models.ValueDescriptor, error) {
 	dSlice := make([]models.ValueDescriptor, 0)
 
 	dec := json.NewDecoder(resp.Body)
@@ -103,5 +103,5 @@ func (v *ValueDescriptorClient) ValueDescriptors() ([]models.ValueDescriptor, er
 		return []models.ValueDescriptor{}, errors.New(string(bodyString))
 	}
 
-	return decodeValueDescriptorSlice(resp)
+	return v.decodeValueDescriptorSlice(resp)
 }

--- a/coredataclients/coredata-clients.go
+++ b/coredataclients/coredata-clients.go
@@ -18,12 +18,14 @@
 package coredataclients
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/edgexfoundry/core-domain-go/models"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 )
 
 var (
@@ -72,6 +74,19 @@ func (v *ValueDescriptorClient) decodeValueDescriptorSlice(resp *http.Response) 
 	return dSlice, err
 }
 
+// Helper method to decode a device and return the device
+func (v *ValueDescriptorClient) decodeValueDescriptor(resp *http.Response) (models.ValueDescriptor, error) {
+	dec := json.NewDecoder(resp.Body)
+	vdr := models.ValueDescriptor{}
+
+	err := dec.Decode(&vdr)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return vdr, err
+}
+
 // Get a list of all value descriptors
 func (v *ValueDescriptorClient) ValueDescriptors() ([]models.ValueDescriptor, error) {
 	req, err := http.NewRequest("GET", v.url, nil)
@@ -104,4 +119,344 @@ func (v *ValueDescriptorClient) ValueDescriptors() ([]models.ValueDescriptor, er
 	}
 
 	return v.decodeValueDescriptorSlice(resp)
+}
+
+// Get the value descriptor by id
+func (v *ValueDescriptorClient) ValueDescriptor(id string) (models.ValueDescriptor, error) {
+	req, err := http.NewRequest("GET", v.url+"/"+id, nil)
+	if err != nil {
+		fmt.Println(err)
+		return models.ValueDescriptor{}, err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return models.ValueDescriptor{}, err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return models.ValueDescriptor{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return models.ValueDescriptor{}, err
+		}
+		bodyString := string(bodyBytes)
+
+		return models.ValueDescriptor{}, errors.New(bodyString)
+	}
+
+	return v.decodeValueDescriptor(resp)
+}
+
+// Get the value descriptor by name
+func (v *ValueDescriptorClient) ValueDescriptorForName(name string) (models.ValueDescriptor, error) {
+	req, err := http.NewRequest("GET", v.url+"/name/"+url.QueryEscape(name), nil)
+	if err != nil {
+		fmt.Println(err)
+		return models.ValueDescriptor{}, err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return models.ValueDescriptor{}, err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return models.ValueDescriptor{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return models.ValueDescriptor{}, err
+		}
+		bodyString := string(bodyBytes)
+
+		return models.ValueDescriptor{}, errors.New(bodyString)
+	}
+	return v.decodeValueDescriptor(resp)
+}
+
+// Get the value descriptors by label
+func (v *ValueDescriptorClient) ValueDescriptorsByLabel(label string) ([]models.ValueDescriptor, error) {
+	req, err := http.NewRequest("GET", v.url+"/label/"+url.QueryEscape(label), nil)
+	if err != nil {
+		fmt.Println(err)
+		return []models.ValueDescriptor{}, err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return []models.ValueDescriptor{}, err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return []models.ValueDescriptor{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return []models.ValueDescriptor{}, err
+		}
+		bodyString := string(bodyBytes)
+
+		return []models.ValueDescriptor{}, errors.New(bodyString)
+	}
+	return v.decodeValueDescriptorSlice(resp)
+}
+
+// Get the value descriptors for a device (by id)
+func (v *ValueDescriptorClient) ValueDescriptorsForDevice(deviceId string) ([]models.ValueDescriptor, error) {
+	req, err := http.NewRequest("GET", v.url+"/deviceid/"+deviceId, nil)
+	if err != nil {
+		fmt.Println(err)
+		return []models.ValueDescriptor{}, err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return []models.ValueDescriptor{}, err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return []models.ValueDescriptor{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return []models.ValueDescriptor{}, err
+		}
+		bodyString := string(bodyBytes)
+
+		return []models.ValueDescriptor{}, errors.New(bodyString)
+	}
+	return v.decodeValueDescriptorSlice(resp)
+}
+
+// Get the value descriptors for a device (by name)
+func (v *ValueDescriptorClient) ValueDescriptorsForDeviceByName(deviceName string) ([]models.ValueDescriptor, error) {
+	req, err := http.NewRequest("GET", v.url+"/devicename/"+deviceName, nil)
+	if err != nil {
+		fmt.Println(err)
+		return []models.ValueDescriptor{}, err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return []models.ValueDescriptor{}, err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return []models.ValueDescriptor{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return []models.ValueDescriptor{}, err
+		}
+		bodyString := string(bodyBytes)
+
+		return []models.ValueDescriptor{}, errors.New(bodyString)
+	}
+	return v.decodeValueDescriptorSlice(resp)
+}
+
+// Get the value descriptors for a uomLabel
+func (v *ValueDescriptorClient) ValueDescriptorsByUomLabel(uomLabel string) ([]models.ValueDescriptor, error) {
+	req, err := http.NewRequest("GET", v.url+"/uomlabel/"+uomLabel, nil)
+	if err != nil {
+		fmt.Println(err)
+		return []models.ValueDescriptor{}, err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return []models.ValueDescriptor{}, err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return []models.ValueDescriptor{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return []models.ValueDescriptor{}, err
+		}
+		bodyString := string(bodyBytes)
+
+		return []models.ValueDescriptor{}, errors.New(bodyString)
+	}
+	return v.decodeValueDescriptorSlice(resp)
+}
+
+// Add a value descriptor
+func (v *ValueDescriptorClient) Add(vdr *models.ValueDescriptor) (string, error) {
+	jsonStr, err := json.Marshal(vdr)
+	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", v.url, bytes.NewReader(jsonStr))
+	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return "", ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	// Get the response body
+	bodyBytes, err := getBody(resp)
+	if err != nil {
+		fmt.Println(err.Error())
+		return "", err
+	}
+	bodyString := string(bodyBytes)
+
+	if resp.StatusCode != 200 {
+		return "", errors.New(bodyString)
+	}
+
+	return bodyString, nil
+}
+
+// update a value descriptor
+func (v *ValueDescriptorClient) Update(vdr *models.ValueDescriptor) error {
+	jsonStr, err := json.Marshal(&vdr)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", v.url, bytes.NewReader(jsonStr))
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return err
+		}
+		bodyString := string(bodyBytes)
+
+		return errors.New(bodyString)
+	}
+
+	return nil
+}
+
+// Delete a value descriptor (specified by id)
+func (v *ValueDescriptorClient) Delete(id string) error {
+	req, err := http.NewRequest("DELETE", v.url+"/id/"+id, nil)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return err
+		}
+		bodyString := string(bodyBytes)
+
+		return errors.New(bodyString)
+	}
+
+	return nil
+}
+
+// Delete a value descriptor (specified by name)
+func (v *ValueDescriptorClient) DeleteByName(name string) error {
+	req, err := http.NewRequest("DELETE", v.url+"/name/"+name, nil)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	if resp == nil {
+		fmt.Println(ErrResponseNil)
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			fmt.Println(err.Error())
+			return err
+		}
+		bodyString := string(bodyBytes)
+
+		return errors.New(bodyString)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This patch moves `decodeValueDescriptorSlice()` method to
the ValueDescriptorClient.

Signed-off-by: Kei Ohmura <ohmura.kei@gmail.com>